### PR TITLE
Fixed Timestamp serialization/deserialization, added tests for OrderBy tests

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -526,6 +526,13 @@ func valueFromGoReflectValue(v reflect.Value) (Value, error) {
 	case reflect.Bool:
 		return BoolValue(v.Bool()), nil
 	case reflect.String:
+		if strings.HasPrefix(v.String(), TimestampValuePrefix) {
+			timeWithoutPrefix := strings.TrimPrefix(v.String(), TimestampValuePrefix)
+			t, err := time.Parse(time.RFC3339, timeWithoutPrefix)
+			if err == nil {
+				return TimestampValue(t), nil
+			}
+		}
 		return StringValue(v.String()), nil
 	case reflect.Slice, reflect.Array:
 		if v.Type().Elem().Kind() == reflect.Uint8 {

--- a/internal/function_aggregate.go
+++ b/internal/function_aggregate.go
@@ -80,22 +80,10 @@ func (f *ARRAY_AGG) Step(v Value, opt *AggregatorOption) error {
 }
 
 func (f *ARRAY_AGG) Done() (Value, error) {
-	if f.opt != nil && len(f.opt.OrderBy) != 0 {
-		sort.Slice(f.values, func(i, j int) bool {
-			for orderBy := 0; orderBy < len(f.opt.OrderBy); orderBy++ {
-				isAsc := f.opt.OrderBy[orderBy].IsAsc
-				result, areEqual, _ := shouldComeBefore(
-					f.values[i].OrderBy[orderBy].Value,
-					f.values[j].OrderBy[orderBy].Value,
-					isAsc,
-				)
-				if !areEqual {
-					return result
-				}
-			}
-			return false
-		})
+	if f.opt != nil {
+		sortValues(f.opt.OrderBy, f.values)
 	}
+
 	if f.opt != nil && f.opt.Limit != nil {
 		minLen := int64(len(f.values))
 		if *f.opt.Limit < minLen {
@@ -133,21 +121,8 @@ func (f *ARRAY_CONCAT_AGG) Step(v *ArrayValue, opt *AggregatorOption) error {
 }
 
 func (f *ARRAY_CONCAT_AGG) Done() (Value, error) {
-	if f.opt != nil && len(f.opt.OrderBy) != 0 {
-		sort.Slice(f.values, func(i, j int) bool {
-			for orderBy := 0; orderBy < len(f.opt.OrderBy); orderBy++ {
-				isAsc := f.opt.OrderBy[orderBy].IsAsc
-				result, areEqual, _ := shouldComeBefore(
-					f.values[i].OrderBy[orderBy].Value,
-					f.values[j].OrderBy[orderBy].Value,
-					isAsc,
-				)
-				if !areEqual {
-					return result
-				}
-			}
-			return false
-		})
+	if f.opt != nil {
+		sortValues(f.opt.OrderBy, f.values)
 	}
 	if f.opt != nil && f.opt.Limit != nil {
 		minLen := int64(len(f.values))
@@ -467,21 +442,8 @@ func (f *STRING_AGG) Step(v Value, delim string, opt *AggregatorOption) error {
 }
 
 func (f *STRING_AGG) Done() (Value, error) {
-	if f.opt != nil && len(f.opt.OrderBy) != 0 {
-		sort.Slice(f.values, func(i, j int) bool {
-			for orderBy := 0; orderBy < len(f.opt.OrderBy); orderBy++ {
-				isAsc := f.opt.OrderBy[orderBy].IsAsc
-				result, areEqual, _ := shouldComeBefore(
-					f.values[i].OrderBy[orderBy].Value,
-					f.values[j].OrderBy[orderBy].Value,
-					isAsc,
-				)
-				if !areEqual {
-					return result
-				}
-			}
-			return false
-		})
+	if f.opt != nil {
+		sortValues(f.opt.OrderBy, f.values)
 	}
 	if f.opt != nil && f.opt.Limit != nil {
 		minLen := int64(len(f.values))

--- a/internal/function_window_option.go
+++ b/internal/function_window_option.go
@@ -411,7 +411,7 @@ func (s *WindowFuncAggregatedStatus) Done(cb func([]Value, int, int) error) erro
 			sort.Slice(sortedValues, func(i, j int) bool {
 				for orderBy := 0; orderBy < len(orderByObjects); orderBy++ {
 					isAsc := orderByObjects[orderBy].IsAsc
-					result, areEqual, _ := shouldComeBefore(
+					result, areEqual, _ := lowerThanEquals(
 						sortedValues[i].OrderBy[orderBy].Value,
 						sortedValues[j].OrderBy[orderBy].Value,
 						isAsc,

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -26,3 +26,131 @@ func TestToLocation(t *testing.T) {
 		}
 	})
 }
+
+func TestSortValues(t *testing.T) {
+	t.Run("Order by ascending", func(t *testing.T) {
+		orderedValues := []*OrderedValue{
+			createOrderedValues([]int64{1, 10, 20}),
+			createOrderedValues([]int64{5, 2, 10}),
+			createOrderedValues([]int64{5, 2, 1}),
+			createOrderedValues([]int64{5, 3, 3}),
+			createOrderedValues([]int64{3, 4, 3}),
+		}
+		orderByList := createOrderByList([]bool{true, true, true})
+
+		sortValues(orderByList, orderedValues)
+
+		expectedValues := [][]int64{
+			{1, 10, 20},
+			{3, 4, 3},
+			{5, 2, 1},
+			{5, 2, 10},
+			{5, 3, 3},
+		}
+		validateNewOrder(t, expectedValues, orderedValues)
+	})
+
+	t.Run("Order by with ascending and descending", func(t *testing.T) {
+		orderedValues := []*OrderedValue{
+			createOrderedValues([]int64{1, 10, 20}),
+			createOrderedValues([]int64{5, 2, 10}),
+			createOrderedValues([]int64{5, 2, 1}),
+			createOrderedValues([]int64{5, 3, 3}),
+			createOrderedValues([]int64{3, 4, 3}),
+		}
+		orderByList := createOrderByList([]bool{true, false, false})
+
+		sortValues(orderByList, orderedValues)
+
+		expectedValues := [][]int64{
+			{1, 10, 20},
+			{3, 4, 3},
+			{5, 3, 3},
+			{5, 2, 10},
+			{5, 2, 1},
+		}
+		validateNewOrder(t, expectedValues, orderedValues)
+	})
+
+	t.Run("No order by values (sort is not performed)", func(t *testing.T) {
+		orderedValues := []*OrderedValue{
+			createOrderedValues([]int64{1}),
+			createOrderedValues([]int64{5}),
+			createOrderedValues([]int64{5}),
+			createOrderedValues([]int64{5}),
+			createOrderedValues([]int64{3}),
+		}
+		orderByList := createOrderByList([]bool{})
+
+		sortValues(orderByList, orderedValues)
+
+		expectedValues := [][]int64{
+			{1},
+			{5},
+			{5},
+			{5},
+			{3},
+		}
+		validateNewOrder(t, expectedValues, orderedValues)
+	})
+}
+
+// Converts int64 array to a OrderedValue container with the same values (as IntValue)
+func createOrderedValues(values []int64) *OrderedValue {
+	var orderByObjects []*AggregateOrderBy
+
+	for _, value := range values {
+		orderByObjects = append(orderByObjects, &AggregateOrderBy{Value: IntValue(value)})
+	}
+
+	return &OrderedValue{OrderBy: orderByObjects}
+}
+
+// Converts boolean array, order-by-direction array (whether ascending order or descending order).
+// True translates to ascending order. False translates to descending order.
+func createOrderByList(values []bool) []*AggregateOrderBy {
+	var orderByObjects []*AggregateOrderBy
+
+	for _, value := range values {
+		orderByObjects = append(orderByObjects, &AggregateOrderBy{IsAsc: value})
+	}
+
+	return orderByObjects
+}
+
+// Converts OrderValue container into an array of int64. Assumes all values are of type IntValue
+func getIntValues(orderedValues *OrderedValue) []int64 {
+	var intValues []int64
+
+	for _, orderedValue := range orderedValues.OrderBy {
+		intValue := int64(orderedValue.Value.(IntValue))
+		intValues = append(intValues, intValue)
+	}
+
+	return intValues
+}
+
+// Compares two int64 slices.
+// Returns True if lists are equal (all values are equal in the same order). False otherwise.
+func slicesEqual(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Validates all values in OrderedValue containers (assumes all values are of type IntValue) match the expected values.
+// Fails tests if values don't match.
+func validateNewOrder(t *testing.T, expectedValues [][]int64, actualValues []*OrderedValue) {
+	for i, expectedValuesArray := range expectedValues {
+		actualValuesArray := getIntValues(actualValues[i])
+		if !slicesEqual(expectedValuesArray, actualValuesArray) {
+			t.Errorf("Sort result is not as expected")
+		}
+	}
+}

--- a/internal/value.go
+++ b/internal/value.go
@@ -1897,6 +1897,14 @@ func (t TimeValue) Interface() interface{} {
 
 type TimestampValue time.Time
 
+const TimestampValuePrefix string = "__TIMESTAMP__"
+
+func (t TimestampValue) MarshalJSON() ([]byte, error) {
+	timeString := time.Time(t).Format(time.RFC3339)
+	jsonString := fmt.Sprintf("%s%s", TimestampValuePrefix, timeString)
+	return json.Marshal(jsonString)
+}
+
 func (t TimestampValue) AddValueWithPart(v time.Duration, part string) (Value, error) {
 	switch part {
 	case "MICROSECOND":
@@ -2036,7 +2044,11 @@ func (t TimestampValue) ToStruct() (*StructValue, error) {
 }
 
 func (t TimestampValue) ToJSON() (string, error) {
-	return t.ToString()
+	s, err := t.ToString()
+	if err != nil {
+		return "", err
+	}
+	return strconv.Quote(s), nil
 }
 
 func (t TimestampValue) ToTime() (time.Time, error) {


### PR DESCRIPTION
There were two main problems with `TimestampValue`:
1. It didn't convert to json, so when propagated via serialization, the timestamp value was lost -- added serialization function and deserialization handling for timestamps. I'm not sure this is the ideal way.
2. Timestamp values didn't have quotes when converted to JSON via the ToJSON() function, which lead to an invalid json (it couldn't recognize the timestamp as a value) - fixed by adding quotes like other values.

Also performed some refactoring in the OrderBy for aggregation methods, reducing code duplication.
And added unit tests for the sortValues function 
 