### PR TITLE
Allow OVER(PARTITION BY NULL)

### DIFF
--- a/internal/function_window_option.go
+++ b/internal/function_window_option.go
@@ -314,7 +314,9 @@ func parseWindowOptions(args ...Value) ([]Value, *WindowFuncStatus, error) {
 		case WindowFuncOptionEnd:
 			opt.End = v.Value.(*WindowBoundary)
 		case WindowFuncOptionPartition:
-			opt.Partitions = append(opt.Partitions, v.Value.(Value))
+			if v.Value != nil {
+			    opt.Partitions = append(opt.Partitions, v.Value.(Value))
+			}
 		case WindowFuncOptionRowID:
 			opt.RowID = v.Value.(int64)
 		case WindowFuncOptionOrderBy:


### PR DESCRIPTION
This change is relevant to window function (e.g. `ROW_NUMBER() OVER(PARTITION BY field1 ORDER BY field2`).
It is valid to use `OVER(PARTITION BY NULL)`, which should be equivalent to `OVER()` (which is also valid).
However, using `PARTITION BY NULL` caused a null reference panic.

