### PR TITLE
in zetasqlite_decode_array - allow to decode nil value

### DIFF
--- a/internal/function_register.go
+++ b/internal/function_register.go
@@ -427,9 +427,14 @@ func RegisterFunctions(conn *sqlite3.SQLiteConn) error {
 		if err != nil {
 			return "", err
 		}
-		array, err := decoded.ToArray()
-		if err != nil {
-			return "", err
+		var array *ArrayValue
+		if decoded != nil {
+			array, err = decoded.ToArray()
+			if err != nil {
+				return "", err
+			}
+		} else {
+			array = &ArrayValue{values: make([]Value, 0)}
 		}
 		encodedValues := make([]interface{}, 0, len(array.values))
 		for _, value := range array.values {


### PR DESCRIPTION
In some cases, the function `zetasqlite_decode_array` received a nil value. 
This fix handles it - it returns an empty array instead of crashing